### PR TITLE
Added support for Markup Formatter in the LeaderBoard to allow use of the Escaped Markup Formatter to prevent xss

### DIFF
--- a/src/main/resources/hudson/plugins/cigame/LeaderBoardAction/index.jelly
+++ b/src/main/resources/hudson/plugins/cigame/LeaderBoardAction/index.jelly
@@ -13,7 +13,7 @@
           		<j:forEach var="userscore" items="${it.userScores}">
     	      		<tr>
         				<td><a href="${rootURL}/${userscore.user.url}">${userscore.user}</a></td>
-					    <td>${userscore.description}</td>
+					    <td><j:out value="${userscore.description!=null ? app.markupFormatter.translate(userscore.description) : ''}" /></td>
         				<td>${userscore.score}</td>
         			</tr> 
           		</j:forEach>


### PR DESCRIPTION
Added support for Markup Formatter in the LeaderBoard for displaying the user's description.
