### PR TITLE
Add pep8 violatios to default rules

### DIFF
--- a/src/main/java/hudson/plugins/cigame/rules/plugins/violation/ViolationsRuleSet.java
+++ b/src/main/java/hudson/plugins/cigame/rules/plugins/violation/ViolationsRuleSet.java
@@ -16,6 +16,7 @@ public class ViolationsRuleSet extends PluginRuleSet {
         add(new DefaultViolationRule("checkstyle", Messages.ViolationRuleSet_CheckstyleRule_Name(), -1, 1)); //$NON-NLS-1$ //$NON-NLS-2$
         add(new DefaultViolationRule("findbugs", Messages.ViolationRuleSet_FindBugsRule_Name(), -1, 1)); //$NON-NLS-1$ //$NON-NLS-2$
         add(new DefaultViolationRule("fxcop", Messages.ViolationRuleSet_FxcopRule_Name(), -1, 1)); //$NON-NLS-1$ //$NON-NLS-2$
+        add(new DefaultViolationRule("pep8", Messages.ViolationRuleSet_Pep8Rule_Name(), -1, 1)); //$NON-NLS-1$ //$NON-NLS-2$
         add(new DefaultViolationRule("simian", Messages.ViolationRuleSet_SimianRule_Name(), -5, 5)); //$NON-NLS-1$ //$NON-NLS-2$
         add(new DefaultViolationRule("stylecop", Messages.ViolationRuleSet_StylecopRule_Name(), -1, 1)); //$NON-NLS-1$ //$NON-NLS-2$
     }

--- a/src/main/resources/hudson/plugins/cigame/rules/plugins/violation/Messages.properties
+++ b/src/main/resources/hudson/plugins/cigame/rules/plugins/violation/Messages.properties
@@ -4,6 +4,7 @@ ViolationRuleSet.DefaultRule.FixedViolationsCount={0} {1} were fixed
 ViolationRuleSet.DefaultRule.NewViolationsCount={0} new {1} were found
 ViolationRuleSet.FindBugsRule.Name=FindBugs violation
 ViolationRuleSet.FxcopRule.Name=FXCop violation
+ViolationRuleSet.Pep8Rule.Name=PEP8 violation
 ViolationRuleSet.PmdRule.Name=PMD violation
 ViolationRuleSet.PylintRule.Name=pylint violation
 ViolationRuleSet.SimianRule.Name=Simian violation

--- a/src/main/resources/hudson/plugins/cigame/rules/plugins/violation/Messages_sv.properties
+++ b/src/main/resources/hudson/plugins/cigame/rules/plugins/violation/Messages_sv.properties
@@ -5,6 +5,7 @@ ViolationRuleSet.DefaultRule.FixedViolationsCount={0} {1} fixades.
 ViolationRuleSet.DefaultRule.NewViolationsCount={0} nya {1} hittades.
 ViolationRuleSet.FindBugsRule.Name=FindBugs varning
 ViolationRuleSet.FxcopRule.Name=FXCop varning
+ViolationRuleSet.Pep8Rule.Name=PEP8 varning
 ViolationRuleSet.PmdRule.Name=PMD varning
 ViolationRuleSet.PylintRule.Name=pylint varning
 ViolationRuleSet.SimianRule.Name=Simian varning


### PR DESCRIPTION
I added pep8 violations to the default rules. I haven't tested it, but there didn't seem to be a lot of room to fail.
