### PR TITLE
Changeset for multi level job

### DIFF
--- a/src/test/java/hudson/plugins/cigame/GamePublisherTest.java
+++ b/src/test/java/hudson/plugins/cigame/GamePublisherTest.java
@@ -37,6 +37,7 @@ public class GamePublisherTest {
         verify(actions).add(isA(ScoreCardAction.class));
         verify(build).getChangeSet();
         verify(build).getPreviousBuild();
+        verify(build).getCauses();
         verifyNoMoreInteractions(build);
     }
 


### PR DESCRIPTION
When we set up a multi level job, the leaf jobs were not able to get the change set. Due to which the game is not able to update the score for the concerned player. Now it would recursively get to the topmost job and add that job to the list of accountable builds.