### PR TITLE
Avoid user to change score

### DIFF
--- a/src/main/java/hudson/plugins/cigame/UserScorePropertyDescriptor.java
+++ b/src/main/java/hudson/plugins/cigame/UserScorePropertyDescriptor.java
@@ -1,14 +1,14 @@
 package hudson.plugins.cigame;
 
-import net.sf.json.JSONObject;
-
 import org.kohsuke.stapler.StaplerRequest;
 
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Hudson;
 import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
+import net.sf.json.JSONObject;
 
 /**
  * Descriptor for the {@link UserScoreProperty}.
@@ -37,6 +37,11 @@ public class UserScorePropertyDescriptor extends UserPropertyDescriptor {
     private UserScoreProperty newInstanceIfJSONIsNull(StaplerRequest req) throws FormException {
         String scoreStr = Util.fixEmpty(req.getParameter("game.score")); //$NON-NLS-1$
         if (scoreStr != null) {
+            if (getCurrentUserScore() != getRequestScore(scoreStr)) {
+                if (!Hudson.getInstance().getACL().hasPermission(Hudson.ADMINISTER)) {
+                    throw new hudson.model.Descriptor.FormException(Messages.UserScore_Cheating_Message(), "game.score");
+                }
+            }
             return new UserScoreProperty(Double.parseDouble(scoreStr), req.getParameter("game.participatingInGame") != null, null); //$NON-NLS-1$
         }
         return new UserScoreProperty();
@@ -44,10 +49,16 @@ public class UserScorePropertyDescriptor extends UserPropertyDescriptor {
 
     @Override
     public UserScoreProperty newInstance(StaplerRequest req, JSONObject formData) throws hudson.model.Descriptor.FormException {
+
         if (formData == null) {
             return newInstanceIfJSONIsNull(req);
         }
         if (formData.has("score")) { //$NON-NLS-1$
+            if (getCurrentUserScore() != getRequestScore(formData.get("score").toString())) {
+                if (!Hudson.getInstance().getACL().hasPermission(Hudson.ADMINISTER)) {
+                    throw new hudson.model.Descriptor.FormException(Messages.UserScore_Cheating_Message(), "score");
+                }
+            }
             return req.bindJSON(UserScoreProperty.class, formData);
         }
         return new UserScoreProperty();
@@ -56,5 +67,21 @@ public class UserScorePropertyDescriptor extends UserPropertyDescriptor {
     @Override
     public UserProperty newInstance(User arg0) {
         return null;
+    }
+
+    private double getCurrentUserScore() {
+        UserScoreProperty property = User.current().getProperty(UserScoreProperty.class);
+        return property != null ? property.getScore() : 0.0;
+    }
+
+    private double getRequestScore(String strNumber) {
+       if (strNumber != null && strNumber.length() > 0) {
+           try {
+              return Double.parseDouble(strNumber);
+           } catch(Exception e) {
+                // do nothing
+           }
+       }
+       return 0;
     }
 }

--- a/src/main/java/hudson/plugins/cigame/UserScorePropertyDescriptor.java
+++ b/src/main/java/hudson/plugins/cigame/UserScorePropertyDescriptor.java
@@ -70,6 +70,9 @@ public class UserScorePropertyDescriptor extends UserPropertyDescriptor {
     }
 
     private double getCurrentUserScore() {
+        if (User.current() == null) {
+            return 0;
+        }
         UserScoreProperty property = User.current().getProperty(UserScoreProperty.class);
         return property != null ? property.getScore() : 0.0;
     }

--- a/src/main/resources/hudson/plugins/cigame/Messages.properties
+++ b/src/main/resources/hudson/plugins/cigame/Messages.properties
@@ -2,3 +2,4 @@ User.Property.Title=Continuous Integration game
 Leaderboard.Title=Leader board
 Plugin.Title=Continuous Integration game
 Scorecard.Title=Score card
+UserScore.Cheating.Message=No cheating!

--- a/src/main/resources/hudson/plugins/cigame/Messages_sv.properties
+++ b/src/main/resources/hudson/plugins/cigame/Messages_sv.properties
@@ -2,3 +2,4 @@ Leaderboard.Title=CI Spelet
 Plugin.Title=CI Spelet
 Scorecard.Title=Score kort
 User.Property.Title=CI spelet
+UserScore.Cheating.Message=Ingen snyd!

--- a/src/main/resources/hudson/plugins/cigame/UserScoreProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/cigame/UserScoreProperty/config.jelly
@@ -1,9 +1,17 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%User.IsParticipating}">
-		<f:checkbox name="game.participatingInGame" checked="${h.defaultToTrue(instance.participatingInGame)}" />
-	</f:entry>
-	<f:entry title="${%User.CurrentScore}">
-		<f:textbox name="game.score" value="${instance.score}" disabled="disabled" readonly="readonly"/>
-	</f:entry>
+    <f:entry title="${%User.IsParticipating}">
+        <f:checkbox name="game.participatingInGame" checked="${h.defaultToTrue(instance.participatingInGame)}" />
+    </f:entry>
+    <f:entry title="${%User.CurrentScore}">
+        <j:choose>
+            <j:when test="${h.hasPermission(app.ADMINISTER)}">
+                <f:textbox name="game.score" value="${instance.score}" />
+            </j:when>
+            <j:otherwise>
+                <input type="hidden" name="game.score" value="${instance.score}"/>
+                ${instance.score}
+            </j:otherwise>
+        </j:choose>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
Hi, here a solution that I implemented to avoid user to change score.
Details:
- User with ADMINISTER privilege can update user's score with the initial form from /user/{username}/configure
- An authenticated user can only see his score as text and if he try to edit the hidden input, a java control throw a FormException