### PR TITLE
Fixing FindBugs maven support

### DIFF
--- a/src/main/java/hudson/plugins/cigame/rules/plugins/findbugs/AbstractFindBugsWarningsRule.java
+++ b/src/main/java/hudson/plugins/cigame/rules/plugins/findbugs/AbstractFindBugsWarningsRule.java
@@ -85,9 +85,6 @@ public abstract class AbstractFindBugsWarningsRule implements AggregatableRule<I
 	private RuleResult<Integer> evaluateMaven(AbstractBuild<?, ?> previousBuild, AbstractBuild<?, ?> build) {
 		List<FindBugsMavenResultAction> currentActions = ActionRetriever.getResult(build, Result.UNSTABLE,
 				FindBugsMavenResultAction.class);
-		if (currentActions.isEmpty()) {
-			return null;
-		}
 		int currentAnnotations = getNumberOfMavenAnnotations(currentActions);
 		
 		List<FindBugsMavenResultAction> previousActions = ActionRetriever.getResult(previousBuild, Result.UNSTABLE, FindBugsMavenResultAction.class);

--- a/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/FindBugsWarningsRuleTestUtils.java
+++ b/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/FindBugsWarningsRuleTestUtils.java
@@ -1,0 +1,49 @@
+package hudson.plugins.cigame.rules.plugins.findbugs;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import hudson.model.AbstractBuild;
+import hudson.plugins.analysis.core.HealthDescriptor;
+import hudson.plugins.analysis.util.model.Priority;
+import hudson.plugins.findbugs.FindBugsMavenResultAction;
+import hudson.plugins.findbugs.FindBugsResult;
+import hudson.plugins.findbugs.FindBugsResultAction;
+
+/**
+ * Utility class to perform common tasks required by FindBugs tests.
+ * 
+ * @author lewisvail3
+ *
+ */
+public class FindBugsWarningsRuleTestUtils {
+
+    /**
+     * Adds FindBugsResltActions to the passed in build
+     * 
+     * @param build
+     * @param numberOfWarnings
+     */
+    public static void addFindBugsWarnings(AbstractBuild<?, ?> build, int numberOfWarnings) {
+        FindBugsResult result = mock(FindBugsResult.class);
+        FindBugsResultAction action = new FindBugsResultAction(build, mock(HealthDescriptor.class), result);
+        when(build.getActions(FindBugsResultAction.class)).thenReturn(Arrays.asList(action));
+        
+        when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(numberOfWarnings);
+    }
+    
+    /**
+     * Adds FindBugsMavenResultActions to the passed in build
+     * @param build
+     * @param numberOfWarnings
+     */
+    public static void addMavenFindBugsWarnings(AbstractBuild<?, ?> build, int numberOfWarnings) {
+        FindBugsResult result = mock(FindBugsResult.class);
+        FindBugsMavenResultAction action = new FindBugsMavenResultAction(build, mock(HealthDescriptor.class), "UTF-8", result);
+        when(build.getActions(FindBugsMavenResultAction.class)).thenReturn(Arrays.asList(action));
+        
+        when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(numberOfWarnings);
+    }
+}

--- a/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/FixedFindBugsWarningsRuleTest.java
+++ b/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/FixedFindBugsWarningsRuleTest.java
@@ -27,11 +27,11 @@ public class FixedFindBugsWarningsRuleTest {
     public void assertFailedBuildsIsWorthZeroPoints() {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getResult()).thenReturn(Result.FAILURE);
-        addFindBugsWarnings(build, 0);
+        FindBugsWarningsRuleTestUtils.addFindBugsWarnings(build, 0);
         
         AbstractBuild prevBuild = mock(AbstractBuild.class);
         when(prevBuild.getResult()).thenReturn(Result.SUCCESS);
-        addFindBugsWarnings(prevBuild, 7);
+        FindBugsWarningsRuleTestUtils.addFindBugsWarnings(prevBuild, 7);
 
         FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
         RuleResult ruleResult = rule.evaluate(prevBuild, build);
@@ -43,11 +43,11 @@ public class FixedFindBugsWarningsRuleTest {
     public void assertFailedMavenBuildsIsWorthZeroPoints() {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getResult()).thenReturn(Result.FAILURE);
-        addMavenFindBugsWarnings(build, 0);
+        FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(build, 0);
         
         AbstractBuild prevBuild = mock(AbstractBuild.class);
         when(prevBuild.getResult()).thenReturn(Result.SUCCESS);
-        addMavenFindBugsWarnings(prevBuild, 7);
+        FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(prevBuild, 7);
 
         FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
         RuleResult ruleResult = rule.evaluate(prevBuild, build);
@@ -60,7 +60,7 @@ public class FixedFindBugsWarningsRuleTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getResult()).thenReturn(Result.FAILURE);
         when(build.getPreviousBuild()).thenReturn(null);
-        addFindBugsWarnings(build, 0);
+        FindBugsWarningsRuleTestUtils.addFindBugsWarnings(build, 0);
 
         FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
         RuleResult ruleResult = rule.evaluate(null, build);
@@ -73,7 +73,7 @@ public class FixedFindBugsWarningsRuleTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getResult()).thenReturn(Result.FAILURE);
         when(build.getPreviousBuild()).thenReturn(null);
-        addMavenFindBugsWarnings(build, 0);
+        FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(build, 0);
 
         FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
         RuleResult ruleResult = rule.evaluate(null, build);
@@ -158,26 +158,10 @@ public class FixedFindBugsWarningsRuleTest {
     public void assertRemovedMavenModuleCountsAsFixed() {
         AbstractBuild previousBuild = mock(MavenBuild.class);
         when(previousBuild.getResult()).thenReturn(Result.SUCCESS);
-        addMavenFindBugsWarnings(previousBuild, 6);
+        FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(previousBuild, 6);
         
         RuleResult ruleResult= new FixedFindBugsWarningsRule(Priority.LOW, 1).evaluate(previousBuild, null);
         assertNotNull(ruleResult);
         assertThat("Points should be 6", ruleResult.getPoints(), is(6d));
-    }
-    
-    private static void addFindBugsWarnings(AbstractBuild<?, ?> build, int numberOfWarnings) {
-        FindBugsResult result = mock(FindBugsResult.class);
-        FindBugsResultAction action = new FindBugsResultAction(build, mock(HealthDescriptor.class), result);
-        when(build.getActions(FindBugsResultAction.class)).thenReturn(Arrays.asList(action));
-        
-        when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(numberOfWarnings);
-    }
-    
-    private static void addMavenFindBugsWarnings(AbstractBuild<?, ?> build, int numberOfWarnings) {
-        FindBugsResult result = mock(FindBugsResult.class);
-        FindBugsMavenResultAction action = new FindBugsMavenResultAction(build, mock(HealthDescriptor.class), "UTF-8", result);
-        when(build.getActions(FindBugsMavenResultAction.class)).thenReturn(Arrays.asList(action));
-        
-        when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(numberOfWarnings);
     }
 }

--- a/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/FixedFindBugsWarningsRuleTest.java
+++ b/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/FixedFindBugsWarningsRuleTest.java
@@ -113,16 +113,16 @@ public class FixedFindBugsWarningsRuleTest {
         when(build.getResult()).thenReturn(Result.SUCCESS);
         when(previousBuild.getResult()).thenReturn(Result.FAILURE);
         FindBugsResult result = mock(FindBugsResult.class);
-        FindBugsResult previosResult = mock(FindBugsResult.class);
+        FindBugsResult previousResult = mock(FindBugsResult.class);
         FindBugsMavenResultAction action = new FindBugsMavenResultAction(build, mock(HealthDescriptor.class), "UTF-8", result);
-        FindBugsMavenResultAction previousAction = new FindBugsMavenResultAction(previousBuild, mock(HealthDescriptor.class), "UTF-8", previosResult);
+        FindBugsMavenResultAction previousAction = new FindBugsMavenResultAction(previousBuild, mock(HealthDescriptor.class), "UTF-8", previousResult);
         when(build.getActions(FindBugsMavenResultAction.class)).thenReturn(Arrays.asList(action));
         when(build.getAction(FindBugsMavenResultAction.class)).thenReturn(action);
         when(previousBuild.getAction(FindBugsMavenResultAction.class)).thenReturn(previousAction);
         when(previousBuild.getActions(FindBugsMavenResultAction.class)).thenReturn(Arrays.asList(previousAction));
         
         when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(5);
-        when(previosResult.getNumberOfAnnotations(Priority.LOW)).thenReturn(10);
+        when(previousResult.getNumberOfAnnotations(Priority.LOW)).thenReturn(10);
 
         RuleResult ruleResult = new FixedFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
@@ -156,7 +156,7 @@ public class FixedFindBugsWarningsRuleTest {
     
     @Test
     public void assertRemovedMavenModuleCountsAsFixed() {
-    	AbstractBuild previousBuild = mock(MavenBuild.class);
+        AbstractBuild previousBuild = mock(MavenBuild.class);
         when(previousBuild.getResult()).thenReturn(Result.SUCCESS);
         addMavenFindBugsWarnings(previousBuild, 6);
         
@@ -166,7 +166,7 @@ public class FixedFindBugsWarningsRuleTest {
     }
     
     private static void addFindBugsWarnings(AbstractBuild<?, ?> build, int numberOfWarnings) {
-    	FindBugsResult result = mock(FindBugsResult.class);
+        FindBugsResult result = mock(FindBugsResult.class);
         FindBugsResultAction action = new FindBugsResultAction(build, mock(HealthDescriptor.class), result);
         when(build.getActions(FindBugsResultAction.class)).thenReturn(Arrays.asList(action));
         
@@ -174,7 +174,7 @@ public class FixedFindBugsWarningsRuleTest {
     }
     
     private static void addMavenFindBugsWarnings(AbstractBuild<?, ?> build, int numberOfWarnings) {
-    	FindBugsResult result = mock(FindBugsResult.class);
+        FindBugsResult result = mock(FindBugsResult.class);
         FindBugsMavenResultAction action = new FindBugsMavenResultAction(build, mock(HealthDescriptor.class), "UTF-8", result);
         when(build.getActions(FindBugsMavenResultAction.class)).thenReturn(Arrays.asList(action));
         

--- a/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/FixedFindBugsWarningsRuleTest.java
+++ b/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/FixedFindBugsWarningsRuleTest.java
@@ -10,6 +10,7 @@ import hudson.model.Result;
 import hudson.plugins.analysis.core.HealthDescriptor;
 import hudson.plugins.analysis.util.model.Priority;
 import hudson.plugins.cigame.model.RuleResult;
+import hudson.plugins.findbugs.FindBugsMavenResultAction;
 import hudson.plugins.findbugs.FindBugsResult;
 import hudson.plugins.findbugs.FindBugsResultAction;
 
@@ -39,11 +40,40 @@ public class FixedFindBugsWarningsRuleTest {
     }
     
     @Test
+    public void assertFailedMavenBuildsIsWorthZeroPoints() {
+        AbstractBuild build = mock(AbstractBuild.class);
+        when(build.getResult()).thenReturn(Result.FAILURE);
+        addMavenFindBugsWarnings(build, 0);
+        
+        AbstractBuild prevBuild = mock(AbstractBuild.class);
+        when(prevBuild.getResult()).thenReturn(Result.SUCCESS);
+        addMavenFindBugsWarnings(prevBuild, 7);
+
+        FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
+        RuleResult ruleResult = rule.evaluate(prevBuild, build);
+        assertNotNull("Rule result must not be null", ruleResult);
+        assertThat("Points should be zero", ruleResult.getPoints(), is((double) 0));
+    }
+    
+    @Test
     public void assertNoPreviousBuildIsWorthZeroPoints() { 
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getResult()).thenReturn(Result.FAILURE);
         when(build.getPreviousBuild()).thenReturn(null);
         addFindBugsWarnings(build, 0);
+
+        FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
+        RuleResult ruleResult = rule.evaluate(null, build);
+        assertNotNull("Rule result must not be null", ruleResult);
+        assertThat("Points should be zero", ruleResult.getPoints(), is((double) 0));
+    }
+    
+    @Test
+    public void assertNoPreviousMavenBuildIsWorthZeroPoints() { 
+        AbstractBuild build = mock(AbstractBuild.class);
+        when(build.getResult()).thenReturn(Result.FAILURE);
+        when(build.getPreviousBuild()).thenReturn(null);
+        addMavenFindBugsWarnings(build, 0);
 
         FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
         RuleResult ruleResult = rule.evaluate(null, build);
@@ -66,6 +96,30 @@ public class FixedFindBugsWarningsRuleTest {
         when(build.getAction(FindBugsResultAction.class)).thenReturn(action);
         when(previousBuild.getAction(FindBugsResultAction.class)).thenReturn(previousAction);
         when(previousBuild.getActions(FindBugsResultAction.class)).thenReturn(Arrays.asList(previousAction));
+        
+        when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(5);
+        when(previosResult.getNumberOfAnnotations(Priority.LOW)).thenReturn(10);
+
+        RuleResult ruleResult = new FixedFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
+        assertNotNull("Rule result must not be null", ruleResult);
+        assertThat("Points should be 0", ruleResult.getPoints(), is(0d));
+    }
+    
+    @Test
+    public void assertIfPreviousMavenBuildFailedResultIsWorthZeroPoints() {
+        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractBuild previousBuild = mock(AbstractBuild.class);
+        when(build.getPreviousBuild()).thenReturn(previousBuild);
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+        when(previousBuild.getResult()).thenReturn(Result.FAILURE);
+        FindBugsResult result = mock(FindBugsResult.class);
+        FindBugsResult previosResult = mock(FindBugsResult.class);
+        FindBugsMavenResultAction action = new FindBugsMavenResultAction(build, mock(HealthDescriptor.class), "UTF-8", result);
+        FindBugsMavenResultAction previousAction = new FindBugsMavenResultAction(previousBuild, mock(HealthDescriptor.class), "UTF-8", previosResult);
+        when(build.getActions(FindBugsMavenResultAction.class)).thenReturn(Arrays.asList(action));
+        when(build.getAction(FindBugsMavenResultAction.class)).thenReturn(action);
+        when(previousBuild.getAction(FindBugsMavenResultAction.class)).thenReturn(previousAction);
+        when(previousBuild.getActions(FindBugsMavenResultAction.class)).thenReturn(Arrays.asList(previousAction));
         
         when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(5);
         when(previosResult.getNumberOfAnnotations(Priority.LOW)).thenReturn(10);
@@ -104,7 +158,7 @@ public class FixedFindBugsWarningsRuleTest {
     public void assertRemovedMavenModuleCountsAsFixed() {
     	AbstractBuild previousBuild = mock(MavenBuild.class);
         when(previousBuild.getResult()).thenReturn(Result.SUCCESS);
-        addFindBugsWarnings(previousBuild, 6);
+        addMavenFindBugsWarnings(previousBuild, 6);
         
         RuleResult ruleResult= new FixedFindBugsWarningsRule(Priority.LOW, 1).evaluate(previousBuild, null);
         assertNotNull(ruleResult);
@@ -115,6 +169,14 @@ public class FixedFindBugsWarningsRuleTest {
     	FindBugsResult result = mock(FindBugsResult.class);
         FindBugsResultAction action = new FindBugsResultAction(build, mock(HealthDescriptor.class), result);
         when(build.getActions(FindBugsResultAction.class)).thenReturn(Arrays.asList(action));
+        
+        when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(numberOfWarnings);
+    }
+    
+    private static void addMavenFindBugsWarnings(AbstractBuild<?, ?> build, int numberOfWarnings) {
+    	FindBugsResult result = mock(FindBugsResult.class);
+        FindBugsMavenResultAction action = new FindBugsMavenResultAction(build, mock(HealthDescriptor.class), "UTF-8", result);
+        when(build.getActions(FindBugsMavenResultAction.class)).thenReturn(Arrays.asList(action));
         
         when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(numberOfWarnings);
     }

--- a/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/FixedFindBugsWarningsRuleTest.java
+++ b/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/FixedFindBugsWarningsRuleTest.java
@@ -20,67 +20,67 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("unchecked")
 public class FixedFindBugsWarningsRuleTest {
     
     @Test
     public void assertFailedBuildsIsWorthZeroPoints() {
-        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
         when(build.getResult()).thenReturn(Result.FAILURE);
         FindBugsWarningsRuleTestUtils.addFindBugsWarnings(build, 0);
         
-        AbstractBuild prevBuild = mock(AbstractBuild.class);
+        AbstractBuild<?, ?> prevBuild = mock(AbstractBuild.class);
         when(prevBuild.getResult()).thenReturn(Result.SUCCESS);
         FindBugsWarningsRuleTestUtils.addFindBugsWarnings(prevBuild, 7);
 
         FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
-        RuleResult ruleResult = rule.evaluate(prevBuild, build);
+        RuleResult<Integer> ruleResult = rule.evaluate(prevBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
-        assertThat("Points should be zero", ruleResult.getPoints(), is((double) 0));
+        assertThat("Points should be zero", ruleResult.getPoints(), is(0.0));
     }
     
     @Test
     public void assertFailedMavenBuildsIsWorthZeroPoints() {
-        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
         when(build.getResult()).thenReturn(Result.FAILURE);
         FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(build, 0);
         
-        AbstractBuild prevBuild = mock(AbstractBuild.class);
+        AbstractBuild<?, ?> prevBuild = mock(AbstractBuild.class);
         when(prevBuild.getResult()).thenReturn(Result.SUCCESS);
         FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(prevBuild, 7);
 
         FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
-        RuleResult ruleResult = rule.evaluate(prevBuild, build);
+        RuleResult<Integer> ruleResult = rule.evaluate(prevBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
-        assertThat("Points should be zero", ruleResult.getPoints(), is((double) 0));
+        assertThat("Points should be zero", ruleResult.getPoints(), is(0.0));
     }
     
     @Test
     public void assertNoPreviousBuildIsWorthZeroPoints() { 
-        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
         when(build.getResult()).thenReturn(Result.FAILURE);
         when(build.getPreviousBuild()).thenReturn(null);
         FindBugsWarningsRuleTestUtils.addFindBugsWarnings(build, 0);
 
         FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
-        RuleResult ruleResult = rule.evaluate(null, build);
+        RuleResult<Integer> ruleResult = rule.evaluate(null, build);
         assertNotNull("Rule result must not be null", ruleResult);
-        assertThat("Points should be zero", ruleResult.getPoints(), is((double) 0));
+        assertThat("Points should be zero", ruleResult.getPoints(), is(0.0));
     }
     
     @Test
     public void assertNoPreviousMavenBuildIsWorthZeroPoints() { 
-        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
         when(build.getResult()).thenReturn(Result.FAILURE);
         when(build.getPreviousBuild()).thenReturn(null);
         FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(build, 0);
 
         FixedFindBugsWarningsRule rule = new FixedFindBugsWarningsRule(Priority.LOW, 100);
-        RuleResult ruleResult = rule.evaluate(null, build);
+        RuleResult<Integer> ruleResult = rule.evaluate(null, build);
         assertNotNull("Rule result must not be null", ruleResult);
-        assertThat("Points should be zero", ruleResult.getPoints(), is((double) 0));
+        assertThat("Points should be zero", ruleResult.getPoints(), is(0.0));
     }
     
+    @SuppressWarnings("rawtypes")
     @Test
     public void assertIfPreviousBuildFailedResultIsWorthZeroPoints() {
         AbstractBuild build = mock(AbstractBuild.class);
@@ -100,11 +100,12 @@ public class FixedFindBugsWarningsRuleTest {
         when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(5);
         when(previosResult.getNumberOfAnnotations(Priority.LOW)).thenReturn(10);
 
-        RuleResult ruleResult = new FixedFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
+        RuleResult<Integer> ruleResult = new FixedFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
         assertThat("Points should be 0", ruleResult.getPoints(), is(0d));
     }
     
+    @SuppressWarnings("rawtypes")
     @Test
     public void assertIfPreviousMavenBuildFailedResultIsWorthZeroPoints() {
         AbstractBuild build = mock(AbstractBuild.class);
@@ -124,11 +125,12 @@ public class FixedFindBugsWarningsRuleTest {
         when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(5);
         when(previousResult.getNumberOfAnnotations(Priority.LOW)).thenReturn(10);
 
-        RuleResult ruleResult = new FixedFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
+        RuleResult<Integer> ruleResult = new FixedFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
         assertThat("Points should be 0", ruleResult.getPoints(), is(0d));
     }
     
+    @SuppressWarnings("rawtypes")
     @Test
     public void assertIfPreviousHasErrorsFailedResultIsWorthZeroPoints() {
         AbstractBuild build = mock(AbstractBuild.class);
@@ -149,18 +151,18 @@ public class FixedFindBugsWarningsRuleTest {
         when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(5);
         when(previosResult.getNumberOfAnnotations(Priority.LOW)).thenReturn(10);
 
-        RuleResult ruleResult = new FixedFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
+        RuleResult<Integer> ruleResult = new FixedFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
         assertThat("Points should be 0", ruleResult.getPoints(), is(0d));
     }
     
     @Test
     public void assertRemovedMavenModuleCountsAsFixed() {
-        AbstractBuild previousBuild = mock(MavenBuild.class);
+        AbstractBuild<?, ?> previousBuild = mock(MavenBuild.class);
         when(previousBuild.getResult()).thenReturn(Result.SUCCESS);
         FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(previousBuild, 6);
         
-        RuleResult ruleResult= new FixedFindBugsWarningsRule(Priority.LOW, 1).evaluate(previousBuild, null);
+        RuleResult<Integer> ruleResult= new FixedFindBugsWarningsRule(Priority.LOW, 1).evaluate(previousBuild, null);
         assertNotNull(ruleResult);
         assertThat("Points should be 6", ruleResult.getPoints(), is(6d));
     }

--- a/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/NewFindBugsWarningsRuleTest.java
+++ b/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/NewFindBugsWarningsRuleTest.java
@@ -27,11 +27,11 @@ public class NewFindBugsWarningsRuleTest {
     public void assertFailedBuildsIsWorthZeroPoints() {
         AbstractBuild build = mock(AbstractBuild.class); 
         when(build.getResult()).thenReturn(Result.FAILURE);
-        addFindBugsWarnings(build, 10);
+        FindBugsWarningsRuleTestUtils.addFindBugsWarnings(build, 10);
         
         AbstractBuild prevBuild = mock(AbstractBuild.class); 
         when(prevBuild.getResult()).thenReturn(Result.SUCCESS);
-        addFindBugsWarnings(prevBuild, 5);
+        FindBugsWarningsRuleTestUtils.addFindBugsWarnings(prevBuild, 5);
 
         NewFindBugsWarningsRule rule = new NewFindBugsWarningsRule(Priority.LOW, 100);
         RuleResult ruleResult = rule.evaluate(prevBuild, build);
@@ -43,11 +43,11 @@ public class NewFindBugsWarningsRuleTest {
     public void assertFailedMavenBuildsIsWorthZeroPoints() {
         AbstractBuild build = mock(AbstractBuild.class); 
         when(build.getResult()).thenReturn(Result.FAILURE);
-        addMavenFindBugsWarnings(build, 10);
+        FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(build, 10);
         
         AbstractBuild prevBuild = mock(AbstractBuild.class); 
         when(prevBuild.getResult()).thenReturn(Result.SUCCESS);
-        addMavenFindBugsWarnings(prevBuild, 5);
+        FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(prevBuild, 5);
 
         NewFindBugsWarningsRule rule = new NewFindBugsWarningsRule(Priority.LOW, 100);
         RuleResult ruleResult = rule.evaluate(prevBuild, build);
@@ -60,7 +60,7 @@ public class NewFindBugsWarningsRuleTest {
         AbstractBuild build = mock(AbstractBuild.class); 
         when(build.getResult()).thenReturn(Result.FAILURE);
         when(build.getPreviousBuild()).thenReturn(null);
-        addFindBugsWarnings(build, 42);
+        FindBugsWarningsRuleTestUtils.addFindBugsWarnings(build, 42);
 
         NewFindBugsWarningsRule rule = new NewFindBugsWarningsRule(Priority.LOW, 100);
         RuleResult ruleResult = rule.evaluate(null, build);
@@ -73,7 +73,7 @@ public class NewFindBugsWarningsRuleTest {
         AbstractBuild build = mock(AbstractBuild.class); 
         when(build.getResult()).thenReturn(Result.FAILURE);
         when(build.getPreviousBuild()).thenReturn(null);
-        addMavenFindBugsWarnings(build, 42);
+        FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(build, 42);
 
         NewFindBugsWarningsRule rule = new NewFindBugsWarningsRule(Priority.LOW, 100);
         RuleResult ruleResult = rule.evaluate(null, build);
@@ -152,26 +152,10 @@ public class NewFindBugsWarningsRuleTest {
     public void assertNewMavenModuleCountsAsNewWarnings() {
     	AbstractBuild build = mock(MavenBuild.class);
         when(build.getResult()).thenReturn(Result.SUCCESS);
-        addMavenFindBugsWarnings(build, 7);
+        FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(build, 7);
         
         RuleResult ruleResult = new NewFindBugsWarningsRule(Priority.LOW, -1).evaluate(null, build);
         assertNotNull(ruleResult);
         assertThat("Points should be -7", ruleResult.getPoints(), is(-7d));
-    }
-    
-    private static void addFindBugsWarnings(AbstractBuild<?, ?> build, int numberOfWarnings) {
-    	FindBugsResult result = mock(FindBugsResult.class);
-        FindBugsResultAction action = new FindBugsResultAction(build, mock(HealthDescriptor.class), result);
-        when(build.getActions(FindBugsResultAction.class)).thenReturn(Arrays.asList(action));
-        
-        when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(numberOfWarnings);
-    }
-    
-    private static void addMavenFindBugsWarnings(AbstractBuild<?, ?> build, int numberOfWarnings) {
-    	FindBugsResult result = mock(FindBugsResult.class);
-    	FindBugsMavenResultAction action = new FindBugsMavenResultAction(build, mock(HealthDescriptor.class), "UTF-8", result);
-        when(build.getActions(FindBugsMavenResultAction.class)).thenReturn(Arrays.asList(action));
-        
-        when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(numberOfWarnings);
     }
 }

--- a/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/NewFindBugsWarningsRuleTest.java
+++ b/src/test/java/hudson/plugins/cigame/rules/plugins/findbugs/NewFindBugsWarningsRuleTest.java
@@ -20,67 +20,67 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
-@SuppressWarnings("unchecked")
 public class NewFindBugsWarningsRuleTest {
     
     @Test
     public void assertFailedBuildsIsWorthZeroPoints() {
-        AbstractBuild build = mock(AbstractBuild.class); 
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class); 
         when(build.getResult()).thenReturn(Result.FAILURE);
         FindBugsWarningsRuleTestUtils.addFindBugsWarnings(build, 10);
         
-        AbstractBuild prevBuild = mock(AbstractBuild.class); 
+        AbstractBuild<?, ?> prevBuild = mock(AbstractBuild.class); 
         when(prevBuild.getResult()).thenReturn(Result.SUCCESS);
         FindBugsWarningsRuleTestUtils.addFindBugsWarnings(prevBuild, 5);
 
         NewFindBugsWarningsRule rule = new NewFindBugsWarningsRule(Priority.LOW, 100);
-        RuleResult ruleResult = rule.evaluate(prevBuild, build);
+        RuleResult<Integer> ruleResult = rule.evaluate(prevBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
-        assertThat("Points should be zero", ruleResult.getPoints(), is((double) 0));
+        assertThat("Points should be zero", ruleResult.getPoints(), is(0.0));
     }
     
     @Test
     public void assertFailedMavenBuildsIsWorthZeroPoints() {
-        AbstractBuild build = mock(AbstractBuild.class); 
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class); 
         when(build.getResult()).thenReturn(Result.FAILURE);
         FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(build, 10);
         
-        AbstractBuild prevBuild = mock(AbstractBuild.class); 
+        AbstractBuild<?, ?> prevBuild = mock(AbstractBuild.class); 
         when(prevBuild.getResult()).thenReturn(Result.SUCCESS);
         FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(prevBuild, 5);
 
         NewFindBugsWarningsRule rule = new NewFindBugsWarningsRule(Priority.LOW, 100);
-        RuleResult ruleResult = rule.evaluate(prevBuild, build);
+        RuleResult<Integer> ruleResult = rule.evaluate(prevBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
-        assertThat("Points should be zero", ruleResult.getPoints(), is((double) 0));
+        assertThat("Points should be zero", ruleResult.getPoints(), is(0.0));
     }
     
     @Test
     public void assertNoPreviousBuildIsWorthZeroPoints() {
-        AbstractBuild build = mock(AbstractBuild.class); 
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class); 
         when(build.getResult()).thenReturn(Result.FAILURE);
         when(build.getPreviousBuild()).thenReturn(null);
         FindBugsWarningsRuleTestUtils.addFindBugsWarnings(build, 42);
 
         NewFindBugsWarningsRule rule = new NewFindBugsWarningsRule(Priority.LOW, 100);
-        RuleResult ruleResult = rule.evaluate(null, build);
+        RuleResult<Integer> ruleResult = rule.evaluate(null, build);
         assertNotNull("Rule result must not be null", ruleResult);
         assertThat("Points should be zero", ruleResult.getPoints(), is((double) 0));
     }
     
     @Test
     public void assertNoPreviousMavenBuildIsWorthZeroPoints() {
-        AbstractBuild build = mock(AbstractBuild.class); 
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class); 
         when(build.getResult()).thenReturn(Result.FAILURE);
         when(build.getPreviousBuild()).thenReturn(null);
         FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(build, 42);
 
         NewFindBugsWarningsRule rule = new NewFindBugsWarningsRule(Priority.LOW, 100);
-        RuleResult ruleResult = rule.evaluate(null, build);
+        RuleResult<Integer> ruleResult = rule.evaluate(null, build);
         assertNotNull("Rule result must not be null", ruleResult);
         assertThat("Points should be zero", ruleResult.getPoints(), is((double) 0));
     }
     
+    @SuppressWarnings("rawtypes")
     @Test
     public void assertIfPreviousBuildFailedResultIsWorthZeroPoints() {
         AbstractBuild build = mock(AbstractBuild.class);
@@ -98,11 +98,12 @@ public class NewFindBugsWarningsRuleTest {
         when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(10);
         when(previosResult.getNumberOfAnnotations(Priority.LOW)).thenReturn(5);
 
-        RuleResult ruleResult = new NewFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
+        RuleResult<Integer> ruleResult = new NewFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
         assertThat("Points should be 0", ruleResult.getPoints(), is(0d));
     }
     
+    @SuppressWarnings("rawtypes")
     @Test
     public void assertIfPreviousMavenBuildFailedResultIsWorthZeroPoints() {
         AbstractBuild build = mock(AbstractBuild.class);
@@ -120,11 +121,12 @@ public class NewFindBugsWarningsRuleTest {
         when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(10);
         when(previosResult.getNumberOfAnnotations(Priority.LOW)).thenReturn(5);
 
-        RuleResult ruleResult = new NewFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
+        RuleResult<Integer> ruleResult = new NewFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
         assertThat("Points should be 0", ruleResult.getPoints(), is(0d));
     }
     
+    @SuppressWarnings("rawtypes")
     @Test
     public void assertIfPreviousHasErrorsResultIsWorthZeroPoints() {
         AbstractBuild build = mock(AbstractBuild.class);
@@ -143,18 +145,18 @@ public class NewFindBugsWarningsRuleTest {
         when(result.getNumberOfAnnotations(Priority.LOW)).thenReturn(10);
         when(previosResult.getNumberOfAnnotations(Priority.LOW)).thenReturn(5);
 
-        RuleResult ruleResult = new NewFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
+        RuleResult<Integer> ruleResult = new NewFindBugsWarningsRule(Priority.LOW, -4).evaluate(previousBuild, build);
         assertNotNull("Rule result must not be null", ruleResult);
         assertThat("Points should be 0", ruleResult.getPoints(), is(0d));
     }
     
     @Test
     public void assertNewMavenModuleCountsAsNewWarnings() {
-    	AbstractBuild build = mock(MavenBuild.class);
+    	AbstractBuild<?, ?> build = mock(MavenBuild.class);
         when(build.getResult()).thenReturn(Result.SUCCESS);
         FindBugsWarningsRuleTestUtils.addMavenFindBugsWarnings(build, 7);
         
-        RuleResult ruleResult = new NewFindBugsWarningsRule(Priority.LOW, -1).evaluate(null, build);
+        RuleResult<Integer> ruleResult = new NewFindBugsWarningsRule(Priority.LOW, -1).evaluate(null, build);
         assertNotNull(ruleResult);
         assertThat("Points should be -7", ruleResult.getPoints(), is(-7d));
     }


### PR DESCRIPTION
Currently, the ci-game plugin doesn't report on FindBugs results generated by a maven project.  This is because the plugin explicitly looks for the FindBugsResultAction class when evaluating a build.  If the build is a maven build, this action class is not present, however the FindBugsMavenResultAction class is.  I've added logic to fall back to check for FindBugsMavenResultActions if FindBugsResultActions are not found when evaluating a build.

In my commits, I've referenced issue JENKINS-23939.  This issue isn't specifically about FindBugs but the summary and description more or less matches in a general sense.  I think it probably makes sense to break up this issue into the various static code analysis plugins affected so they can be fixed piecewise.  I would have created a new issue specific to FindBugs but I don't have a login to the issue management system.